### PR TITLE
refactor: move vehicle props to serverside spawn

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -188,7 +188,7 @@ RegisterNetEvent('qb-garages:client:takeOutGarage', function(data)
         return
     end
 
-    local netId, properties = lib.callback.await('qb-garage:server:spawnvehicle', false, vehicle, type == 'house' and garage.coords or garage.spawn, true)
+    local netId = lib.callback.await('qb-garage:server:spawnvehicle', false, vehicle, type == 'house' and garage.coords or garage.spawn, true)
     local timeout = 100
     while not NetworkDoesEntityExistWithNetworkId(netId) and timeout > 0 do
         Wait(10)
@@ -205,7 +205,6 @@ RegisterNetEvent('qb-garages:client:takeOutGarage', function(data)
     TriggerEvent("vehiclekeys:client:SetOwner", vehicle.plate)
     SetVehicleEngineOn(veh, true, true, false)
     Wait(500)
-    lib.setVehicleProperties(veh, properties)
 end)
 
 local function parkVehicle(veh, indexgarage, type, garage)

--- a/server/main.lua
+++ b/server/main.lua
@@ -72,14 +72,14 @@ lib.callback.register('qb-garage:server:checkOwnership', checkOwnership)
 
 lib.callback.register('qb-garage:server:spawnvehicle', function (source, vehInfo, coords, warp)
     local plate = vehInfo.plate
-    local netId = SpawnVehicle(source, vehInfo.vehicle, coords, warp)
-    local veh = NetworkGetEntityFromNetworkId(netId)
-    SetVehicleNumberPlateText(veh, plate)
     local vehProps = {}
     local result = MySQL.query.await('SELECT mods FROM player_vehicles WHERE plate = ?', {plate})
     if result[1] then vehProps = json.decode(result[1].mods) end
+    local netId = SpawnVehicle(source, vehInfo.vehicle, coords, warp, vehProps)
+    local veh = NetworkGetEntityFromNetworkId(netId)
+    SetVehicleNumberPlateText(veh, plate)
     outsideVehicles[plate] = {netID = netId, entity = veh}
-    return netId, vehProps
+    return netId
 end)
 
 lib.callback.register('qb-garage:server:GetVehicleProperties', function(_, plate)


### PR DESCRIPTION
## Description

SpawnVehicle now supports sending props in the spawn call. This PR moves the props setting to the server and off the client to prevent issues with client ownership of a vehicle entity which typically required placing the player in the vehicle to set the props.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
