### PR TITLE
feat: takeOut config options

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -191,7 +191,7 @@ RegisterNetEvent('qb-garages:client:takeOutGarage', function(data)
         return
     end
 
-    local netId = lib.callback.await('qb-garage:server:spawnvehicle', false, vehicle, type == 'house' and garage.coords or garage.spawn, config.warpInVehicle)
+    local netId = lib.callback.await('qb-garage:server:spawnvehicle', false, vehicle, type == 'house' and garage.coords or garage.spawn, sharedConfig.takeOut.warpInVehicle)
     local timeout = 100
     while not NetworkDoesEntityExistWithNetworkId(netId) and timeout > 0 do
         Wait(10)
@@ -206,6 +206,7 @@ RegisterNetEvent('qb-garages:client:takeOutGarage', function(data)
     doCarDamage(veh, vehicle)
     TriggerServerEvent('qb-garage:server:updateVehicleState', 0, vehicle.plate, index)
     TriggerEvent('vehiclekeys:client:SetOwner', vehicle.plate)
+    if not sharedConfig.takeOut.engineOff then SetVehicleEngineOn(veh, true, true, false) end
     Wait(500)
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -103,10 +103,11 @@ local function displayVehicleInfo(vehicle, type, garage, indexgarage)
     if vehicle.state == 0 then
         if type == 'depot' then
             options[#options + 1] = {
-                title = 'Take out of Impound',
+                title = 'Take out',
                 icon = 'fa-truck-ramp-box',
                 description = '$'..CommaValue(vehicle.depotprice),
                 event = 'qb-garages:client:TakeOutDepot',
+                arrow = true,
                 args = {
                     vehicle = vehicle,
                     type = type,
@@ -116,16 +117,17 @@ local function displayVehicleInfo(vehicle, type, garage, indexgarage)
             }
         else
             options[#options + 1] = {
-                title = 'Your vehicle is already out',
-                icon = 'car-on',
+                title = 'Your vehicle is already out...',
+                icon = 'car',
                 readOnly = true,
             }
         end
     elseif vehicle.state == 1 then
         options[#options + 1] = {
-            title = 'Take Out',
+            title = 'Take out',
             icon = 'car-rear',
             event = 'qb-garages:client:takeOutGarage',
+            arrow = true,
             args = {
                 vehicle = vehicle,
                 type = type,
@@ -162,6 +164,7 @@ local function openGarageMenu(type, garage, indexgarage)
         options[#options + 1] = {
             title = vehLabel,
             description = stateLabel..' | '..v.plate,
+            arrow = true,
             onSelect = function()
                 displayVehicleInfo(v, type, garage, indexgarage)
             end,
@@ -188,7 +191,7 @@ RegisterNetEvent('qb-garages:client:takeOutGarage', function(data)
         return
     end
 
-    local netId = lib.callback.await('qb-garage:server:spawnvehicle', false, vehicle, type == 'house' and garage.coords or garage.spawn, true)
+    local netId = lib.callback.await('qb-garage:server:spawnvehicle', false, vehicle, type == 'house' and garage.coords or garage.spawn, config.warpInVehicle)
     local timeout = 100
     while not NetworkDoesEntityExistWithNetworkId(netId) and timeout > 0 do
         Wait(10)
@@ -202,8 +205,7 @@ RegisterNetEvent('qb-garages:client:takeOutGarage', function(data)
     SetVehicleFuelLevel(veh, vehicle.fuel)
     doCarDamage(veh, vehicle)
     TriggerServerEvent('qb-garage:server:updateVehicleState', 0, vehicle.plate, index)
-    TriggerEvent("vehiclekeys:client:SetOwner", vehicle.plate)
-    SetVehicleEngineOn(veh, true, true, false)
+    TriggerEvent('vehiclekeys:client:SetOwner', vehicle.plate)
     Wait(500)
 end)
 
@@ -364,8 +366,8 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     createGarages()
 end)
 
-AddEventHandler('onResourceStart', function(res)
-    if res ~= GetCurrentResourceName() then return end
+AddEventHandler('onResourceStart', function(resource)
+    if resource ~= cache.resource then return end
     createGarages()
 end)
 

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,6 +1,5 @@
 return {
     useTarget = false,
     debugPoly = false,
-    warpInVehicle = false, -- If true, player will warp into vehicle upon taking the vehicle out.
     visuallyDamageCars = true, -- True == Visually damage cars that go out of the garage depending of body damage, false == Do not visually damage cars (damage is still applied to car values)
 }

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,5 +1,6 @@
 return {
     useTarget = false,
     debugPoly = false,
+    warpInVehicle = false, -- If true, player will warp into vehicle upon taking the vehicle out.
     visuallyDamageCars = true, -- True == Visually damage cars that go out of the garage depending of body damage, false == Do not visually damage cars (damage is still applied to car values)
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,4 +1,10 @@
 return {
+    takeOut = {
+        warpInVehicle = false, -- If false, player will no longer warp into vehicle upon taking the vehicle out.
+        doorsLocked = true, -- If true, the doors will be locked upon taking the vehicle out.
+        engineOff = true, -- If true, the engine will be off upon taking the vehicle out.
+    },
+
     houseGarages = {}, -- Dont touch
     garages = {
 
@@ -13,7 +19,7 @@ return {
         ---@field blipColor number? -- Color for the blip
         ---@field type public | job | gang | depot -- Type of garage
         ---@field vehicle car | air | sea | all -- Vehicle type
-        ---@field job string?       -- Job / Gang name
+        ---@field job string? -- Job / Gang name
         
         ---@type table<garageName, GarageConfig>
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -78,7 +78,7 @@ lib.callback.register('qb-garage:server:spawnvehicle', function (source, vehInfo
     local netId = SpawnVehicle(source, vehInfo.vehicle, coords, warp, vehProps)
     local veh = NetworkGetEntityFromNetworkId(netId)
     SetVehicleNumberPlateText(veh, plate)
-    SetVehicleDoorsLocked(veh, 2)
+    if sharedConfig.takeOut.doorsLocked then SetVehicleDoorsLocked(veh, 2) end
     outsideVehicles[plate] = {netID = netId, entity = veh}
     return netId
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -78,6 +78,7 @@ lib.callback.register('qb-garage:server:spawnvehicle', function (source, vehInfo
     local netId = SpawnVehicle(source, vehInfo.vehicle, coords, warp, vehProps)
     local veh = NetworkGetEntityFromNetworkId(netId)
     SetVehicleNumberPlateText(veh, plate)
+    SetVehicleDoorsLocked(veh, 2)
     outsideVehicles[plate] = {netID = netId, entity = veh}
     return netId
 end)


### PR DESCRIPTION
## Description

Added a takeOut group of config options to allow further customization by the player.

- warpInVehicle: While false, player no longer warps you into their vehicle upon taking it out. (Default is false)
- doorsLocked: While true, the vehicle doors will no longer be unlocked upon taking the vehicle out, forcing the player to unlock it with their keys. (Default is true)
- engineOff: While true, he vehicles engine will no longer be on automatically, forcing the player to get in and wait for their character to start it before driving off. (Default is true)

Minor UI and style edits

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
