### PR TITLE
fix: save vehicle props on vehicle storage

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -53,36 +53,6 @@ local function isOfType(category, vehicle)
     return classSet[GetVehicleClass(vehicle)] == true
 end
 
----@param currentVehicle number
----@param vehicle table
-local function doCarDamage(currentVehicle, vehicle)
-    local engine = vehicle.engine + 0.0
-    local body = vehicle.body + 0.0
-    local data = json.decode(vehicle.mods)
-
-    if config.visuallyDamageCars then
-        for k, v in pairs(data.doors) do
-            if v then
-                SetVehicleDoorBroken(currentVehicle, k, true)
-            end
-        end
-        for k, v in pairs(data.tyres) do
-            if v then
-                local random = math.random(1, 1000)
-                SetVehicleTyreBurst(currentVehicle, k, true, random)
-            end
-        end
-        for k, v in pairs(data.windows) do
-            if not v then
-                SmashVehicleWindow(currentVehicle, k)
-            end
-        end
-    end
-
-    SetVehicleEngineHealth(currentVehicle, engine)
-    SetVehicleBodyHealth(currentVehicle, body)
-end
-
 ---@param vehicle number
 local function checkPlayers(vehicle)
     for i = -1, 5, 1 do
@@ -255,8 +225,6 @@ RegisterNetEvent('qb-garages:client:takeOutGarage', function(data)
         return
     end
 
-    SetVehicleFuelLevel(veh, data.vehicle.fuel)
-    doCarDamage(veh, data.vehicle)
     TriggerServerEvent('qb-garage:server:updateVehicleState', VehicleState.OUT, data.vehicle.plate, data.garageName)
 
     if not sharedConfig.takeOut.engineOff then

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,5 +1,4 @@
 return {
     useTarget = false,
     debugPoly = false,
-    visuallyDamageCars = true, -- True == Visually damage cars that go out of the garage depending of body damage, false == Do not visually damage cars (damage is still applied to car values)
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -80,8 +80,6 @@ lib.callback.register('qb-garage:server:spawnvehicle', function (source, vehInfo
 
     local veh = NetworkGetEntityFromNetworkId(netId)
 
-    SetVehicleNumberPlateText(veh, vehInfo.plate)
-
     if sharedConfig.takeOut.doorsLocked then
         SetVehicleDoorsLocked(veh, 2)
     end
@@ -102,6 +100,11 @@ lib.callback.register('qb-garage:server:IsSpawnOk', function(_, plate, type)
         return not outsideVehicles[plate] or not DoesEntityExist(outsideVehicles[plate].entity)
     end
     return true
+end)
+
+RegisterNetEvent('qb-vehicletuning:server:SaveVehicleProps', function(vehicleProps)
+    MySQL.update('UPDATE player_vehicles SET mods = ? WHERE plate = ?',
+        { json.encode(vehicleProps), vehicleProps.plate })
 end)
 
 RegisterNetEvent('qb-garage:server:updateVehicle', function(state, fuel, engine, body, plate, garage, type, gang)


### PR DESCRIPTION
- Removed config option visuallyDamageCars as vehicle properties will always be applied
- removed duplicate code that would apply the same vehicle properties as lib.setVehicleProperties does.
- temporarily implemented the server side qb-vehicletuning:server:SaveVehicleProps event. In a future PR, will replace this with a callback, rename it, and likely combine it with other db saves.