### PR TITLE
fix(fxmanifest): use correct file path

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -22,7 +22,7 @@ client_scripts {
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
     'server/main.lua',
-    'server/spawn-vehicles.lua',
+    'server/spawn-vehicle.lua',
 }
 
 files {


### PR DESCRIPTION
fix for "Warning: could not find server_script `server/spawn-vehicles.lua` (defined in fxmanifest.lua:22)"

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My pull request fits the contribution guidelines & code conventions.
