### PR TITLE
refactor: move SQL calls to storage layer

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -9,4 +9,12 @@ return {
         -- For example, if your car costs $1000 and this is set to 2, the impound fee will be $20 as that is 2% of the vehicle price
         percentage = 2,
     },
+
+    ---@param garageName string
+    ---@param citizenId string
+    ---@return boolean
+    hasHouseGarageKey = function(garageName, citizenId)
+        --- TODO: implement
+        error('house garages not implemented. Implement in config/server.lua')
+    end,
 }

--- a/server/storage.lua
+++ b/server/storage.lua
@@ -1,0 +1,74 @@
+---Fetches vehicles by citizenid
+---@param garageName string
+---@param citizenId? string
+---@return VehicleEntity[]
+local function fetchGaragedVehicles(garageName, citizenId)
+    if citizenId then
+        return MySQL.query.await('SELECT * FROM player_vehicles WHERE citizenid = ? AND garage = ? AND state = ?', {citizenId, garageName, VehicleState.GARAGED})
+    else
+        return MySQL.query.await('SELECT * FROM player_vehicles WHERE garage = ? AND state = ?', {garageName, VehicleState.GARAGED})
+    end
+end
+
+---@param citizenId string
+---@return VehicleEntity[]
+local function fetchOutVehicles(citizenId)
+    return MySQL.query.await('SELECT * FROM player_vehicles WHERE citizenid = ? AND state = ?', {citizenId, VehicleState.OUT})
+end
+
+---@alias CitizenId string
+
+---@param vehicleId string
+---@return CitizenId owner
+local function fetchVehicleOwner(vehicleId)
+    return MySQL.scalar.await('SELECT citizenid FROM player_vehicles WHERE id = ?', {vehicleId})
+end
+
+---@param vehicleId string
+---@return number
+local function fetchVehicleDepotPrice(vehicleId)
+    return MySQL.scalar.await('SELECT depotprice FROM player_vehicles WHERE id = ?', {vehicleId})
+end
+
+---@param vehicleId string
+---@return {props: table, modelName: string}
+local function fetchVehicleProps(vehicleId)
+    local vehicle = MySQL.single.await('SELECT mods, vehicle FROM player_vehicles WHERE id = ?', {vehicleId})
+    assert(vehicle.mods ~= nil, "vehicle mods is nil for vehicleId=" .. vehicleId)
+    return {
+        props = json.decode(vehicle.mods),
+        modelName = vehicle.vehicle
+    }
+end
+
+---@async
+---@param vehicleId string
+---@param props table ox_lib vehicle properties table
+---@param garageName string
+local function saveVehicle(vehicleId, props, garageName)
+    MySQL.update('UPDATE player_vehicles SET state = ?, garage = ?, fuel = ?, engine = ?, body = ?, mods = ? WHERE id = ?', {VehicleState.GARAGED, garageName, props.fuelLevel, props.engineHealth, props.bodyHealth, json.encode(props), vehicleId})
+end
+
+---@async
+local function moveOutVehiclesIntoGarages()
+    MySQL.update('UPDATE player_vehicles SET state = ? WHERE state = ?', {VehicleState.GARAGED, VehicleState.OUT})
+end
+
+---@async
+---@param vehicleId string
+---@param depotPrice number
+local function setVehicleStateToOut(vehicleId, depotPrice)
+    local state = VehicleState.OUT
+    MySQL.update('UPDATE player_vehicles SET state = ?, depotprice = ? WHERE id = ?', {state, depotPrice, vehicleId})
+end
+
+return {
+    fetchGaragedVehicles = fetchGaragedVehicles,
+    fetchOutVehicles = fetchOutVehicles,
+    fetchVehicleOwner = fetchVehicleOwner,
+    fetchVehicleDepotPrice = fetchVehicleDepotPrice,
+    fetchVehicleProps = fetchVehicleProps,
+    saveVehicle = saveVehicle,
+    moveOutVehiclesIntoGarages = moveOutVehiclesIntoGarages,
+    setVehicleStateToOut = setVehicleStateToOut,
+}


### PR DESCRIPTION
This is an intermittent step. As part of this PR, I also identified some places that we could avoid SQL calls. For example, now that we have vehicleid state bag, we can check it to see if the vehicle is player owned rather than do a db call. Also moved some things around to make a little more sense, like checking if a player has a right to spawn a vehicle before it's spawned instead of after.

Follow-up PRs will start moving some of these storage layer calls to qbx_vehicles. It's useful to see what exactly qbx_garages needs from the database in one place to influence the qbx_vehicles API.