### PR TITLE
refactor(server/spawn-vehicle): style and limit

### DIFF
--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -5,7 +5,7 @@
 ---@return boolean
 local function checkHasAccessToVehicle(source, garageName, garageType, vehicleId)
     local player = exports.qbx_core:GetPlayer(source)
-    local result = nil
+    local result
     if garageType == GarageType.PUBLIC then -- Public garages give player cars in the garage only
         result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE citizenid = ? AND garage = ? AND state = ? AND id = ? LIMIT 1', {player.PlayerData.citizenid, garageName, VehicleState.GARAGED, vehicleId})
     elseif garageType == GarageType.DEPOT then -- Depot give player cars that are not in garage only

--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -6,17 +6,17 @@
 local function checkHasAccessToVehicle(source, garageName, garageType, vehicleId)
     local player = exports.qbx_core:GetPlayer(source)
     if garageType == GarageType.PUBLIC then -- Public garages give player cars in the garage only
-        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE citizenid = ? AND garage = ? AND state = ? AND id = ?', {player.PlayerData.citizenid, garageName, VehicleState.GARAGED, vehicleId})
-        return not not result
+        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE citizenid = ? AND garage = ? AND state = ? AND id = ? LIMIT 1', {player.PlayerData.citizenid, garageName, VehicleState.GARAGED, vehicleId})
+        return result ~= nil
     elseif garageType == GarageType.DEPOT then -- Depot give player cars that are not in garage only
-        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE citizenid = ? AND (state = ? OR state = ?) AND id = ?', {player.PlayerData.citizenid, VehicleState.OUT, VehicleState.IMPOUNDED, vehicleId})
-        return not not result
+        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE citizenid = ? AND (state = ? OR state = ?) AND id = ? LIMIT 1', {player.PlayerData.citizenid, VehicleState.OUT, VehicleState.IMPOUNDED, vehicleId})
+        return result ~= nil
     elseif garageType == GarageType.HOUSE or not Config.sharedGarages then -- House/Personal Job/Gang garages give all cars in the garage
-        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE garage = ? AND state = ? AND citizenid = ? AND id = ?', {garageName, VehicleState.OUT, player.PlayerData.citizenid, vehicleId})
-        return not not result
+        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE garage = ? AND state = ? AND citizenid = ? AND id = ? LIMIT 1', {garageName, VehicleState.OUT, player.PlayerData.citizenid, vehicleId})
+        return result ~= nil
     else -- Job/Gang shared garages
-        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE garage = ? AND state = ?', {garageName, VehicleState.OUT})
-        return not not result
+        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE garage = ? AND state = ? LIMIT 1', {garageName, VehicleState.OUT})
+        return result ~= nil
     end
 end
 

--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -5,19 +5,17 @@
 ---@return boolean
 local function checkHasAccessToVehicle(source, garageName, garageType, vehicleId)
     local player = exports.qbx_core:GetPlayer(source)
+    local result = nil
     if garageType == GarageType.PUBLIC then -- Public garages give player cars in the garage only
-        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE citizenid = ? AND garage = ? AND state = ? AND id = ? LIMIT 1', {player.PlayerData.citizenid, garageName, VehicleState.GARAGED, vehicleId})
-        return result ~= nil
+        result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE citizenid = ? AND garage = ? AND state = ? AND id = ? LIMIT 1', {player.PlayerData.citizenid, garageName, VehicleState.GARAGED, vehicleId})
     elseif garageType == GarageType.DEPOT then -- Depot give player cars that are not in garage only
-        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE citizenid = ? AND (state = ? OR state = ?) AND id = ? LIMIT 1', {player.PlayerData.citizenid, VehicleState.OUT, VehicleState.IMPOUNDED, vehicleId})
-        return result ~= nil
+        result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE citizenid = ? AND (state = ? OR state = ?) AND id = ? LIMIT 1', {player.PlayerData.citizenid, VehicleState.OUT, VehicleState.IMPOUNDED, vehicleId})
     elseif garageType == GarageType.HOUSE or not Config.sharedGarages then -- House/Personal Job/Gang garages give all cars in the garage
-        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE garage = ? AND state = ? AND citizenid = ? AND id = ? LIMIT 1', {garageName, VehicleState.OUT, player.PlayerData.citizenid, vehicleId})
-        return result ~= nil
+        result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE garage = ? AND state = ? AND citizenid = ? AND id = ? LIMIT 1', {garageName, VehicleState.OUT, player.PlayerData.citizenid, vehicleId})
     else -- Job/Gang shared garages
-        local result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE garage = ? AND state = ? LIMIT 1', {garageName, VehicleState.OUT})
-        return result ~= nil
+        result = MySQL.scalar.await('SELECT 1 FROM player_vehicles WHERE garage = ? AND state = ? AND id = ? LIMIT 1', {garageName, VehicleState.OUT, vehicleId})
     end
+    return result ~= nil
 end
 
 ---@param vehicleId string


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
While technically correct `not not result` is a bit less readable compared to `result ~= nil`. Additionally adds LIMIT 1 to the SQL query to prevent edge cases where someone makes vehicleId not unique.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
