### PR TITLE
feat: support for multiple access points per garage

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -66,13 +66,14 @@ end
 
 ---@param vehicleId number
 ---@param garageName string
-local function takeOutOfGarage(vehicleId, garageName)
+---@param accessPoint integer
+local function takeOutOfGarage(vehicleId, garageName, accessPoint)
     if cache.vehicle then
         exports.qbx_core:Notify('You\'re already in a vehicle...')
         return
     end
 
-    local netId = lib.callback.await('qbx_garages:server:spawnVehicle', false, vehicleId, garageName)
+    local netId = lib.callback.await('qbx_garages:server:spawnVehicle', false, vehicleId, garageName, accessPoint)
     if not netId then return end
 
     local veh = lib.waitFor(function()
@@ -91,7 +92,7 @@ local function takeOutOfGarage(vehicleId, garageName)
     end
 end
 
----@param data {vehicle: PlayerVehicle, garageName: string}
+---@param data {vehicle: PlayerVehicle, garageName: string, accessPoint: integer}
 local function takeOutDepot(data)
     if data.vehicle.depotPrice ~= 0 then
         local success = lib.callback.await('qbx_garages:server:payDepotPrice', false, data.vehicle.id)
@@ -101,13 +102,14 @@ local function takeOutDepot(data)
         end
     end
 
-    takeOutOfGarage(data.vehicle.id, data.garageName)
+    takeOutOfGarage(data.vehicle.id, data.garageName, data.accessPoint)
 end
 
 ---@param vehicle PlayerVehicle
 ---@param garageName string
 ---@param garageInfo GarageConfig
-local function displayVehicleInfo(vehicle, garageName, garageInfo)
+---@param accessPoint integer
+local function displayVehicleInfo(vehicle, garageName, garageInfo, accessPoint)
     local engine = qbx.math.round(vehicle.props.engineHealth / 10)
     local body = qbx.math.round(vehicle.props.bodyHealth / 10)
     local engineColor = getProgressColor(engine)
@@ -173,7 +175,7 @@ local function displayVehicleInfo(vehicle, garageName, garageInfo)
             icon = 'car-rear',
             arrow = true,
             onSelect = function()
-                takeOutOfGarage(vehicle.id, garageName)
+                takeOutOfGarage(vehicle.id, garageName, accessPoint)
             end,
         }
     elseif vehicle.state == VehicleState.IMPOUNDED then
@@ -196,7 +198,8 @@ end
 
 ---@param garageName string
 ---@param garageInfo GarageConfig
-local function openGarageMenu(garageName, garageInfo)
+---@param accessPoint integer
+local function openGarageMenu(garageName, garageInfo, accessPoint)
     ---@type PlayerVehicle[]?
     local vehicleEntities = lib.callback.await('qbx_garages:server:getGarageVehicles', false, garageName)
 
@@ -216,7 +219,7 @@ local function openGarageMenu(garageName, garageInfo)
             description = ('%s | %s'):format(stateLabel, vehicleEntity.props.plate),
             arrow = true,
             onSelect = function()
-                displayVehicleInfo(vehicleEntity, garageName, garageInfo)
+                displayVehicleInfo(vehicleEntity, garageName, garageInfo, accessPoint)
             end,
         }
     end
@@ -253,13 +256,15 @@ end
 
 ---@param garageName string
 ---@param garage GarageConfig
-local function createZones(garageName, garage)
+---@param accessPoint AccessPoint
+---@param accessPointIndex integer
+local function createZones(garageName, garage, accessPoint, accessPointIndex)
     CreateThread(function()
         if not config.useTarget then
             lib.zones.box({
-                coords = garage.coords.xyz,
-                size = garage.size,
-                rotation = garage.coords.w,
+                coords = accessPoint.coords.xyz,
+                size = accessPoint.size,
+                rotation = accessPoint.coords.w,
                 onEnter = function()
                     lib.showTextUI((garage.type == GarageType.DEPOT and 'E - Open Impound') or (cache.vehicle and 'E - Store Vehicle') or 'E - Open Garage')
                 end,
@@ -274,7 +279,7 @@ local function createZones(garageName, garage)
                             end
                             parkVehicle(cache.vehicle, garageName)
                         else
-                            openGarageMenu(garageName, garage)
+                            openGarageMenu(garageName, garage, accessPointIndex)
                         end
                     end
                 end,
@@ -282,9 +287,9 @@ local function createZones(garageName, garage)
             })
         else
             exports.ox_target:addBoxZone({
-                coords = garage.coords.xyz,
-                size = garage.size,
-                rotation = garage.coords.w,
+                coords = accessPoint.coords.xyz,
+                size = accessPoint.size,
+                rotation = accessPoint.coords.w,
                 debug = config.debugPoly,
                 options = {
                     {
@@ -292,7 +297,7 @@ local function createZones(garageName, garage)
                         label = garage.type == GarageType.DEPOT and 'Open Impound' or 'Open Garage',
                         icon = 'fas fa-car',
                         onSelect = function()
-                            openGarageMenu(garageName, garage)
+                            openGarageMenu(garageName, garage, accessPointIndex)
                         end,
                         distance = 10,
                     },
@@ -318,28 +323,34 @@ local function createZones(garageName, garage)
 end
 
 ---@param garageInfo GarageConfig
-local function createBlips(garageInfo)
-    local blip = AddBlipForCoord(garageInfo.coords.x, garageInfo.coords.y, garageInfo.coords.z)
-    SetBlipSprite(blip, garageInfo.blip.sprite or 357)
+---@param accessPoint AccessPoint
+local function createBlips(garageInfo, accessPoint)
+    local blip = AddBlipForCoord(accessPoint.coords.x, accessPoint.coords.y, accessPoint.coords.z)
+    SetBlipSprite(blip, accessPoint.blip.sprite or 357)
     SetBlipDisplay(blip, 4)
     SetBlipScale(blip, 0.60)
     SetBlipAsShortRange(blip, true)
-    SetBlipColour(blip, garageInfo.blip.color or 3)
+    SetBlipColour(blip, accessPoint.blip.color or 3)
     BeginTextCommandSetBlipName('STRING')
-    AddTextComponentSubstringPlayerName(garageInfo.blip.name or garageInfo.label)
+    AddTextComponentSubstringPlayerName(accessPoint.blip.name or garageInfo.label)
     EndTextCommandSetBlipName(blip)
 end
 
 local function createGarages()
     for name, garage in pairs(sharedConfig.garages) do
-        if garage.blip then
-            createBlips(garage)
-        end
+        local accessPoints = garage.accessPoints
+        for i = 1, #accessPoints do
+            local accessPoint = accessPoints[i]
 
-        if garage.type == GarageType.JOB and (QBX.PlayerData.job.name == garage.group or QBX.PlayerData.job.type == garage.group) or
-            garage.type == GarageType.GANG and QBX.PlayerData.gang.name == garage.group or
-            garage.type ~= GarageType.JOB and garage.type ~= GarageType.GANG then
-            createZones(name, garage)
+            if accessPoint.blip then
+                createBlips(garage, accessPoint)
+            end
+
+            if garage.type == GarageType.JOB and (QBX.PlayerData.job.name == garage.group or QBX.PlayerData.job.type == garage.group) or
+                garage.type == GarageType.GANG and QBX.PlayerData.gang.name == garage.group or
+                garage.type ~= GarageType.JOB and garage.type ~= GarageType.GANG then
+                createZones(name, garage, accessPoint, i)
+            end
         end
     end
 end

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -14,286 +14,402 @@ return {
     ---@field sprite? number -- Sprite for the blip. Defaults to 357
     ---@field color? number -- Color for the blip. Defaults to 3.
 
+    ---The place where the player can access the garage and spawn a car
+    ---@class AccessPoint
+    ---@field coords vector4 where the garage menu can be accessed from
+    ---@field blip? GarageBlip
+    ---@field size vector3
+    ---@field spawn vector4 where the vehicle will spawn
+
     ---@class GarageConfig
     ---@field label string -- Label for the garage
-    ---@field coords vector4 -- Coordinates for the garage
-    ---@field size vector3 -- Size of the garage
-    ---@field spawn vector4 -- Coordinates where the vehicle will spawn
-    ---@field blip? GarageBlip
     ---@field type GarageType -- Type of garage
     ---@field vehicleType VehicleType -- Vehicle type
     ---@field group? string -- Job / Gang name that can access the garage.
+    ---@field accessPoints AccessPoint[]
 
     ---@type table<string, GarageConfig>
     garages = {
         -- Public Garages
         motelgarage = {
             label = 'Motel Parking',
-            coords = vec4(275.58, -344.74, 45.17, 70.0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(271.26, -342.32, 44.7, 159.97),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(275.58, -344.74, 45.17, 70.0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(271.26, -342.32, 44.7, 159.97),
+                }
+            },
         },
         sapcounsel = {
             label = 'San Andreas Parking',
-            coords = vec4(-330.67, -781.12, 33.96, 40.46),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-337.11, -775.34, 33.56, 132.09),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(-330.67, -781.12, 33.96, 40.46),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-337.11, -775.34, 33.56, 132.09),
+                }
+            },
         },
         spanishave = {
             label = 'Spanish Ave Parking',
-            coords = vec4(-1160.46, -741.04, 19.95, 41.26),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-1165.38, -747.65, 18.94, 40.45),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(-1160.46, -741.04, 19.95, 41.26),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-1165.38, -747.65, 18.94, 40.45),
+                }
+            },
         },
         caears24 = {
             label = 'Caears 24 Parking',
-            coords = vec4(68.08, 13.15, 69.21, 160.44),
-            size = vec3(10, 10, 10),
-            spawn = vec4(72.61, 11.72, 68.47, 157.59),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(68.08, 13.15, 69.21, 160.44),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(72.61, 11.72, 68.47, 157.59),
+                },
+            },
         },
         littleseoul = {
             label = 'Little Seoul Parking',
-            coords = vec4(-463.51, -808.2, 30.54, 0.0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-472.24, -813.61, 30.3, 179.88),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(-463.51, -808.2, 30.54, 0.0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-472.24, -813.61, 30.3, 179.88),
+                }
+            },
         },
         lagunapi = {
             label = 'Laguna Parking',
-            coords = vec4(363.85, 297.97, 103.5, 341.39),
-            size = vec3(10, 10, 10),
-            spawn = vec4(367.41, 297.02, 103.2, 341.08),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(363.85, 297.97, 103.5, 341.39),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(367.41, 297.02, 103.2, 341.08),
+                }
+            },
         },
         airportp = {
             label = 'Airport Parking',
-            coords = vec4(-796.07, -2023.26, 9.17, 55.18),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-793.35, -2020.62, 8.51, 58.42),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(-796.07, -2023.26, 9.17, 55.18),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-793.35, -2020.62, 8.51, 58.42),
+                }
+            },
         },
         beachp = {
             label = 'Beach Parking',
-            coords = vec4(-1184.21, -1509.65, 4.65, 303.72),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-1184.4, -1501.88, 4.39, 214.7),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(-1184.21, -1509.65, 4.65, 303.72),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-1184.4, -1501.88, 4.39, 214.7),
+                }
+            },
         },
         themotorhotel = {
             label = 'The Motor Hotel Parking',
-            coords = vec4(1137.77, 2663.54, 37.9, 0.0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(1137.56, 2674.19, 38.17, 359.95),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(1137.77, 2663.54, 37.9, 0.0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(1137.56, 2674.19, 38.17, 359.95),
+                }
+            },
         },
         liqourparking = {
             label = 'Liqour Parking',
-            coords = vec4(960.68, 3609.32, 32.98, 268.97),
-            size = vec3(10, 10, 10),
-            spawn = vec4(960.48, 3605.71, 32.98, 87.09),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(960.68, 3609.32, 32.98, 268.97),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(960.48, 3605.71, 32.98, 87.09),
+                }
+            },
         },
         shoreparking = {
             label = 'Shore Parking',
-            coords = vec4(1726.9, 3710.38, 34.26, 22.54),
-            size = vec3(10, 10, 10),
-            spawn = vec4(1728.65, 3714.85, 34.18, 21.26),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(1726.9, 3710.38, 34.26, 22.54),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(1728.65, 3714.85, 34.18, 21.26),
+                }
+            },
         },
         haanparking = {
             label = 'Bell Farms Parking',
-            coords = vec4(78.34, 6418.74, 31.28, 0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(70.71, 6425.16, 30.92, 68.5),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(78.34, 6418.74, 31.28, 0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(70.71, 6425.16, 30.92, 68.5),
+                }
+            },
         },
         dumbogarage = {
             label = 'Dumbo Private Parking',
-            coords = vec4(157.26, -3240.00, 7.00, 0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(165.32, -3236.10, 5.93, 268.5),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(157.26, -3240.00, 7.00, 0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(165.32, -3236.10, 5.93, 268.5),
+                }
+            },
         },
         pillboxgarage = {
             label = 'Pillbox Garage Parking',
-            coords = vec4(218.66, -804.08, 30.75, 65.69),
-            size = vec3(10, 10, 10),
-            spawn = vec4(229.33, -805.01, 30.54, 156.79),
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(218.66, -804.08, 30.75, 65.69),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(229.33, -805.01, 30.54, 156.79),
+                }
+            },
         },
         intairport = {
             label = 'Airport Hangar',
-            coords = vec4(-1025.34, -3017.0, 13.95, 331.99),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-979.2, -2995.51, 13.95, 52.19),
-            blip = {
-                name = 'Hanger',
-                sprite = 360,
-            },
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.AIR,
+            accessPoints = {
+                {
+                    coords = vec4(-1025.34, -3017.0, 13.95, 331.99),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-979.2, -2995.51, 13.95, 52.19),
+                    blip = {
+                        name = 'Hanger',
+                        sprite = 360,
+                    },
+                }
+            },
         },
         higginsheli = {
             label = 'Higgins Helitours',
-            coords = vec4(-722.12, -1472.74, 5.0, 140.0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-724.83, -1443.89, 5.0, 140.0),
-            blip = {
-                name = 'Hanger',
-                sprite = 360,
-            },
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.AIR,
+            accessPoints = {
+                {
+                    coords = vec4(-722.12, -1472.74, 5.0, 140.0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-724.83, -1443.89, 5.0, 140.0),
+                    blip = {
+                        name = 'Hanger',
+                        sprite = 360,
+                    },
+                }
+            },
         },
         airsshores = {
             label = 'Sandy Shores Hangar',
-            coords = vec4(1757.74, 3296.13, 41.15, 142.6),
-            size = vec3(10, 10, 10),
-            spawn = vec4(1740.88, 3278.99, 41.09, 189.46),
-            blip = {
-                name = 'Hanger',
-                sprite = 360,
-            },
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.AIR,
+            accessPoints = {
+                {
+                    coords = vec4(1757.74, 3296.13, 41.15, 142.6),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(1740.88, 3278.99, 41.09, 189.46),
+                    blip = {
+                        name = 'Hanger',
+                        sprite = 360,
+                    },
+                }
+            },
         },
         lsymc = {
             label = 'LSYMC Boathouse',
-            coords = vec4(-794.64, -1510.89, 1.6, 201.55),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-793.58, -1501.4, 0.12, 111.5),
-            blip = {
-                name = 'Boathouse',
-                sprite = 356,
-            },
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.SEA,
+            accessPoints = {
+                {
+                    coords = vec4(-794.64, -1510.89, 1.6, 201.55),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-793.58, -1501.4, 0.12, 111.5),
+                    blip = {
+                        name = 'Boathouse',
+                        sprite = 356,
+                    },
+                }
+            },
         },
         paleto = {
             label = 'Paleto Boathouse',
-            coords = vec4(-277.4, 6637.01, 7.5, 40.51),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-289.2, 6637.96, 1.01, 45.5),
-            blip = {
-                name = 'Boathouse',
-                sprite = 356,
-            },
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.SEA,
+            accessPoints = {
+                {
+                    coords = vec4(-277.4, 6637.01, 7.5, 40.51),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-289.2, 6637.96, 1.01, 45.5),
+                    blip = {
+                        name = 'Boathouse',
+                        sprite = 356,
+                    },
+                }
+            },
         },
         millars = {
             label = 'Millars Boathouse',
-            coords = vec4(1299.02, 4216.42, 33.91, 166.8),
-            size = vec3(10, 10, 10),
-            spawn = vec4(1296.78, 4203.76, 30.12, 169.03),
-            blip = {
-                name = 'Boathouse',
-                sprite = 356,
-            },
             type = GarageType.PUBLIC,
             vehicleType = VehicleType.SEA,
+            accessPoints = {
+                {
+                    coords = vec4(1299.02, 4216.42, 33.91, 166.8),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(1296.78, 4203.76, 30.12, 169.03),
+                    blip = {
+                        name = 'Boathouse',
+                        sprite = 356,
+                    },
+                }
+            },
         },
 
         -- Job Garages
         police = {
             label = 'Police',
-            coords = vec4(454.6, -1017.4, 28.4, 0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(438.4, -1018.3, 27.7, 90.0),
             type = GarageType.JOB,
             vehicleType = VehicleType.CAR,
             group = 'police',
+            accessPoints = {
+                {
+                    coords = vec4(454.6, -1017.4, 28.4, 0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(438.4, -1018.3, 27.7, 90.0),
+                }
+            },
         },
 
         -- Gang Garages
         ballas = {
             label = 'Ballas',
-            coords = vec4(98.50, -1954.49, 20.84, 0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(98.50, -1954.49, 20.75, 335.73),
             type = GarageType.GANG,
             vehicleType = VehicleType.CAR,
             group = 'ballas',
+            accessPoints = {
+                {
+                    coords = vec4(98.50, -1954.49, 20.84, 0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(98.50, -1954.49, 20.75, 335.73),
+                }
+            },
         },
         families = {
             label = 'La Familia',
-            coords = vec4(-811.65, 187.49, 72.48, 0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-818.43, 184.97, 72.28, 107.85),
             type = GarageType.GANG,
             vehicleType = VehicleType.CAR,
             group = 'families',
+            accessPoints = {
+                {
+                    coords = vec4(-811.65, 187.49, 72.48, 0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-818.43, 184.97, 72.28, 107.85),
+                }
+            },
         },
         lostmc = {
             label = 'Lost MC',
-            coords = vec4(957.25, -129.63, 74.39, 0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(957.25, -129.63, 74.39, 199.21),
             type = GarageType.GANG,
             vehicleType = VehicleType.CAR,
             group = 'lostmc',
+            accessPoints = {
+                {
+                    coords = vec4(957.25, -129.63, 74.39, 0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(957.25, -129.63, 74.39, 199.21),
+                }
+            },
         },
         cartel = {
             label = 'Cartel',
-            coords = vec4(1407.18, 1118.04, 114.84, 0),
-            size = vec3(10, 10, 10),
-            spawn = vec4(1407.18, 1118.04, 114.84, 88.34),
             type = GarageType.GANG,
             vehicleType = VehicleType.CAR,
             group = 'cartel',
+            accessPoints = {
+                {
+                    coords = vec4(1407.18, 1118.04, 114.84, 0),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(1407.18, 1118.04, 114.84, 88.34),
+                }
+            },
         },
 
         -- Impound Lots
         impoundlot = {
             label = 'Impound Lot',
-            coords = vec4(400.45, -1630.87, 29.29, 228.88),
-            size = vec3(10, 10, 10),
-            spawn = vec4(407.2, -1645.58, 29.31, 228.28),
-            blip = {
-                sprite = 68
-            },
             type = GarageType.DEPOT,
             vehicleType = VehicleType.CAR,
+            accessPoints = {
+                {
+                    coords = vec4(400.45, -1630.87, 29.29, 228.88),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(407.2, -1645.58, 29.31, 228.28),
+                    blip = {
+                        sprite = 68
+                    },
+                }
+            },
         },
         airdepot = {
             label = 'Air Depot',
-            coords = vec4(-1244.35, -3391.39, 13.94, 59.26),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-1269.03, -3376.7, 13.94, 330.32),
-            blip = {
-                sprite = 359,
-            },
             type = GarageType.DEPOT,
             vehicleType = VehicleType.AIR,
+            accessPoints = {
+                {
+                    coords = vec4(-1244.35, -3391.39, 13.94, 59.26),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-1269.03, -3376.7, 13.94, 330.32),
+                    blip = {
+                        sprite = 359,
+                    },
+                }
+            },
         },
         seadepot = {
             label = 'LSYMC Depot',
-            coords = vec4(-772.71, -1431.11, 1.6, 48.03),
-            size = vec3(10, 10, 10),
-            spawn = vec4(-729.77, -1355.49, 1.19, 142.5),
-            blip = {
-                sprite = 356,
-            },
             type = GarageType.DEPOT,
             vehicleType = VehicleType.SEA,
+            accessPoints = {
+                {
+                    coords = vec4(-772.71, -1431.11, 1.6, 48.03),
+                    size = vec3(10, 10, 10),
+                    spawn = vec4(-729.77, -1355.49, 1.19, 142.5),
+                    blip = {
+                        sprite = 356,
+                    },
+                }
+            },
         },
     },
 }

--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -9,8 +9,9 @@ end
 ---@param source number
 ---@param vehicleId string
 ---@param garageName string
+---@param accessPoint integer
 ---@return number? netId
-lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehicleId, garageName)
+lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehicleId, garageName, accessPoint)
     local garage = SharedConfig.garages[garageName]
     local garageType = GetGarageType(garageName)
 
@@ -25,7 +26,7 @@ lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehic
     end
 
     local warpPed = SharedConfig.takeOut.warpInVehicle and GetPlayerPed(source)
-    local netId, veh = qbx.spawnVehicle({ spawnSource = garage.spawn, model = playerVehicle.props.model, props = playerVehicle.props, warp = warpPed})
+    local netId, veh = qbx.spawnVehicle({ spawnSource = garage.accessPoints[accessPoint].spawn, model = playerVehicle.props.model, props = playerVehicle.props, warp = warpPed})
 
     if SharedConfig.takeOut.doorsLocked then
         SetVehicleDoorsLocked(veh, 2)


### PR DESCRIPTION
Adds support to access a garage from more than one access point. This can be useful to create a shared pool of vehicles, accessed from multiple locations, such as a network of public garages. Or a bunch of parking spaces in the same vicinity which access the same garage for example.