### PR TITLE
feat: use ox_target groups filtering

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -336,9 +336,7 @@ local function createGarages()
             createBlips(garage)
         end
 
-        if garage.type == GarageType.JOB and (QBX.PlayerData.job.name == garage.group or QBX.PlayerData.job.type == garage.group) or
-            garage.type == GarageType.GANG and QBX.PlayerData.gang.name == garage.group or
-            garage.type ~= GarageType.JOB and garage.type ~= GarageType.GANG then
+        if garage.groups == nil or HasPlayerGotGroup(garage.groups, QBX.PlayerData) then
             createZones(name, garage)
         end
     end

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -22,7 +22,7 @@ return {
     ---@field blip? GarageBlip
     ---@field type GarageType -- Type of garage
     ---@field vehicleType VehicleType -- Vehicle type
-    ---@field group? string -- Job / Gang name that can access the garage.
+    ---@field groups? string | string[] | table<string, number> job/gangs that can access the garage
 
     ---@type table<string, GarageConfig>
     garages = {

--- a/server/main.lua
+++ b/server/main.lua
@@ -102,13 +102,15 @@ local function isParkable(source, vehicleId, garageName)
     assert(vehicleId ~= nil, 'owned vehicles must have vehicle ids')
     local player = exports.qbx_core:GetPlayer(source)
     local garage = SharedConfig.garages[garageName]
+    if garage.groups and not HasPlayerGotGroup(garage.groups, player.PlayerData) then
+        return false
+    end
     if garageType == GarageType.PUBLIC then -- All players can park in public garages
         return true
     elseif garageType == GarageType.HOUSE then -- House garages only for player cars that have keys of the house
         local playerVehicle = exports.qbx_vehicles:GetPlayerVehicle(vehicleId)
         return Config.hasHouseGarageKey(garageName, playerVehicle.citizenid)
     elseif garageType == GarageType.JOB then
-        if player.PlayerData.job?.name ~= garage.group then return false end
         if Config.sharedGarages then
             return true
         else
@@ -116,7 +118,6 @@ local function isParkable(source, vehicleId, garageName)
             return playerVehicle.citizenid == player.PlayerData.citizenid
         end
     elseif garageType == GarageType.GANG then
-        if player.PlayerData.gang?.name ~= garage.group then return false end
         if Config.sharedGarages then
             return true
         else

--- a/shared/utils.lua
+++ b/shared/utils.lua
@@ -1,0 +1,67 @@
+--- HasPlayerGotGroup function borrowed from ox_target: https://github.com/overextended/ox_target/blob/aefc464d01da9b7aa3565e79161dd0a489945b90/client/framework/qb.lua#L41
+
+-- MIT License
+
+-- Copyright (c) 2022 Overextended
+
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+---@param filter string | string[] | table<string, number>
+---@param playerData table
+---@return boolean
+function HasPlayerGotGroup(filter, playerData)
+    if not filter then return false end
+    local _type = type(filter)
+
+    if _type == 'string' then
+        local job = playerData.job.name == filter
+        local gang = playerData.gang.name == filter
+        local citizenId = playerData.citizenid == filter
+
+        if job or gang or citizenId then
+            return true
+        end
+    elseif _type == 'table' then
+        local tabletype = table.type(filter)
+
+        if tabletype == 'hash' then
+            for name, grade in pairs(filter) do
+                local job = playerData.job.name == name
+                local gang = playerData.gang.name == name
+                local citizenId = playerData.citizenid == name
+
+                if job and grade <= playerData.job.grade.level or gang and grade <= playerData.gang.grade.level or citizenId then
+                    return true
+                end
+            end
+        elseif tabletype == 'array' then
+            for i = 1, #filter do
+                local name = filter[i]
+                local job = playerData.job.name == name
+                local gang = playerData.gang.name == name
+                local citizenId = playerData.citizenid == name
+
+                if job or gang or citizenId then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end


### PR DESCRIPTION
- Using the ox_target filtering code for filtering which groups have access to a garage. This makes the filtering more powerful as multiple groups could be selected, or even specific grades.
- Decouple the group checking from the garage type. This is part of a broader refactor in future PRs to remove most garage types in favor of explicit permissions/filtering. Rather than a garage of type job, it will be a generic garage with a groups filtering applied.