### PR TITLE
refactor!: move shared garages as a field of a garage

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -1,7 +1,5 @@
 return {
     autoRespawn = false, -- True == auto respawn cars that are outside into your garage on script restart, false == does not put them into your garage and players have to go to the impound
-    sharedGarages = false, -- True == Gang and job garages are shared, false == Gang and Job garages are personal
-
     impoundFee = {
         enable = true, -- If true, impound fee is calculated and applied. If false, no impound fee is applied and depotprice remains at 0
 

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -7,8 +7,6 @@ return {
         engineOff = true, -- If true, the engine will be off upon taking the vehicle out.
     },
 
-    houseGarages = {}, -- Dont touch
-
     ---@class GarageBlip
     ---@field name? string -- Name of the blip. Defaults to garage label.
     ---@field sprite? number -- Sprite for the blip. Defaults to 357
@@ -26,6 +24,7 @@ return {
     ---@field type GarageType -- Type of garage
     ---@field vehicleType VehicleType -- Vehicle type
     ---@field groups? string | string[] | table<string, number> job/gangs that can access the garage
+    ---@field shared? boolean defaults to false. Shared garages give all players with access to the garage access to all vehicles in it. If shared is off, the garage will only give access to player's vehicles which they own.
     ---@field accessPoints AccessPoint[]
 
     ---@type table<string, GarageConfig>


### PR DESCRIPTION
Instead of a global config value. This also removes most references to JOB/GANG garage types. They'll be removed along with other types in a future PR once we can replace more of the functionality that the type system still gives.