### PR TITLE
feat: optionally limit the number of vehicles a single player can store in a single garage

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -7,4 +7,6 @@ return {
         -- For example, if your car costs $1000 and this is set to 2, the impound fee will be $20 as that is 2% of the vehicle price
         percentage = 2,
     },
+    ---@type integer
+    defaultMaxSlots = nil -- If a player does not have `maxGarageSlots` metadata set, defaults them to this value when attempting to park a vehicle in a max slots enforced garage. If a player already has the metadata field set, this config value has no effect on them.
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -27,6 +27,7 @@ return {
     ---@field shared? boolean defaults to false. Shared garages give all players with access to the garage access to all vehicles in it. If shared is off, the garage will only give access to player's vehicles which they own.
     ---@field states? VehicleState | VehicleState[] if set, only vehicles in the given states will be retrievable from the garage. Defaults to GARAGED.
     ---@field skipGarageCheck? boolean if true, returns vehicles for retrieval regardless of if that vehicle's garage matches this garage's name
+    ---@field enforceMaxSlots? boolean if true, prevents player from storing a vehicle if they are out of slots. Used slots are counted only towards a single garage for vehicles owned by the player.
     ---@field canAccess? fun(source?: number): boolean runs on both client & server to check access as an additional guard clause. Other filter fields still need to pass in addition to this function.
     ---@field accessPoints AccessPoint[]
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -115,6 +115,23 @@ local function isParkable(source, vehicleId, garageName)
             return false
         end
     end
+    if garage.enforceMaxSlots then
+        local maxSlots = player.Functions.GetMetadata('maxGarageSlots')
+        if not maxSlots and Config.defaultMaxSlots then
+            maxSlots = Config.defaultMaxSlots
+            player.Functions.SetMetadata('maxGarageSlots', maxSlots)
+        end
+        if maxSlots then
+            local garagedVehicles = exports.qbx_vehicles:GetPlayerVehicles({
+                citizenid = player.PlayerData.citizenid,
+                garage = garageName,
+                states = VehicleState.GARAGED,
+            })
+            if garagedVehicles >= maxSlots then
+                return false
+            end
+        end
+    end
     return true
 end
 


### PR DESCRIPTION
Limitations of this design

- Assumes that there is a single maximum slots a player can have instead of setting this value per garage. Maybe a player should only be able to store 1 vehicle in a public garage, but 3 vehicles in a house garage. This is not possible with the current design.
- Assumes that the limit should not change based on the player. Maybe a house garage for example would be unlimited for the owner only, whereas guests can park a max of 1 vehicle. In the current design this is not possible as limits are enforced for all players, or none.
- Assumes that the limit should be player based rather than garage based. While a player based limit makes sense for interacting with public garages, player owned garages, such as job and house garages, may make more sense to have a garage side limit. This could still be implemented in the future however as a separate feature.