### PR TITLE
fix: group permissions checked at runtime instead of initial load

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -273,6 +273,10 @@ local function createZones(garageName, garage, accessPoint, accessPointIndex)
             end,
             inside = function()
                 if IsControlJustReleased(0, 38) then
+                    if garage.groups and not exports.qbx_core:HasPrimaryGroup(garage.groups, QBX.PlayerData) then
+                        exports.qbx_core:Notify("You don't have access to this garage", 'error')
+                        return
+                    end
                     if garage.canAccess ~= nil and not garage.canAccess() then
                         exports.qbx_core:Notify("You don't have access to this garage", 'error')
                         return
@@ -315,9 +319,7 @@ local function createGarage(name, garage)
             createBlips(garage, accessPoint)
         end
 
-        if garage.groups == nil or exports.qbx_core:HasPrimaryGroup(garage.groups, QBX.PlayerData) then
-            createZones(name, garage, accessPoint, i)
-        end
+        createZones(name, garage, accessPoint, i)
     end
 end
 


### PR DESCRIPTION
Previously, group permissions were checked to create the garage interactions, but not the blip. This caused an issue for players switching jobs who may enter or leave permission for a given garage. I considered doing loop checking to keep the blips/zones created only for people with the job, but I ended up going with a simpler approach, which is to create the garage interactions for all players, show the blips to all players (this was already the case), and check the group permissions at runtime.

A future improvement may be showing/hiding blips based on permissions, but this is probably not a key feature.