### PR TITLE
fix(server): get the garages from the correct config

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -18,7 +18,7 @@ SharedConfig = require 'config.shared'
 VEHICLES = exports.qbx_core:GetVehiclesByName()
 Storage = require 'server.storage'
 ---@type table<string, GarageConfig>
-Garages = SharedConfig.garages
+Garages = Config.garages
 
 lib.callback.register('qbx_garages:server:getGarages', function()
     return Garages


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
My pull request changes the config used for getting garages from the shared config to the server config. The server config contains the actual garage data, which fixes the issue of garages not being retrieved correctly and resulting in a nil value / no Garages.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
