### PR TITLE
feat: disable client config option for custom UIs

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,4 +1,5 @@
 local config = require 'config.client'
+if not config.enableClient then return end
 local sharedConfig = require 'config.shared'
 local VEHICLES = exports.qbx_core:GetVehiclesByName()
 

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,3 +1,4 @@
 return {
     debugPoly = false,
+    enableClient = true, -- disable to create your own client interface
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,5 @@
 assert(lib.checkDependency('qbx_core', '1.15.0', true))
+assert(lib.checkDependency('qbx_vehicles', '1.1.0', true))
 
 ---@class ErrorResult
 ---@field code string


### PR DESCRIPTION
qbx_garage server side is a pretty generic garage backend with an export API. This introduces a config option to disable to built-in client files so that someone can make a custom UI that hooks into the qbx_garages backend.