### PR TITLE
fix(spawn-vehicle): use vec3 not vec4 for dist check

### DIFF
--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -13,7 +13,7 @@ end
 lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehicleId, garageName, accessPointIndex)
     local garage = Garages[garageName]
     local accessPoint = garage.accessPoints[accessPointIndex]
-    if #(GetEntityCoords(GetPlayerPed(source)) - accessPoint.coords) > 3 then
+    if #(GetEntityCoords(GetPlayerPed(source)) - accessPoint.coords.xyz) > 3 then
         lib.print.error(string.format("player %s attempted to spawn a vehicle but was too far from the access point", source))
         return
     end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
GetEntityCoords returns a Vec3 value not a Vec4 which are not directly compatible. Adding .xyz creates a temporary vec3 for the vector distance calculation

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
