### PR TITLE
fix: canAccess function runs only on server

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -251,10 +251,6 @@ local function checkCanAccess(garage)
         exports.qbx_core:Notify(locale('error.no_access'), 'error')
         return false
     end
-    if garage.canAccess ~= nil and not garage.canAccess() then
-        exports.qbx_core:Notify(locale('error.no_access'), 'error')
-        return false
-    end
     if cache.vehicle and not isOfType(garage.vehicleType, cache.vehicle) then
         exports.qbx_core:Notify(locale('error.not_correct_type'), 'error')
         return false

--- a/config/server.lua
+++ b/config/server.lua
@@ -32,7 +32,7 @@ return {
     ---@field shared? boolean defaults to false. Shared garages give all players with access to the garage access to all vehicles in it. If shared is off, the garage will only give access to player's vehicles which they own.
     ---@field states? VehicleState | VehicleState[] if set, only vehicles in the given states will be retrievable from the garage. Defaults to GARAGED.
     ---@field skipGarageCheck? boolean if true, returns vehicles for retrieval regardless of if that vehicle's garage matches this garage's name
-    ---@field canAccess? fun(source?: number): boolean runs on both client & server to check access as an additional guard clause. Other filter fields still need to pass in addition to this function.
+    ---@field canAccess? fun(source: number): boolean checks access as an additional guard clause. Other filter fields still need to pass in addition to this function.
     ---@field accessPoints AccessPoint[]
 
     ---@type table<string, GarageConfig>


### PR DESCRIPTION
the canAccess function was attempting to run on the client, but as functions can't be passed across the network, this would cause an error. Instead, the client calls have been removed and the config language no longer states it can be run on the client.