### PR TITLE
fix(client): prevent taking out a vehicle until the first one has spa…

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -7,7 +7,8 @@
         "not_correct_type": "You can't store this type of vehicle here",
         "not_enough": "Not enough money",
         "vehicle_occupied": "You can't store this vehicle as it is not empty",
-        "in_vehicle": "You're already in a vehicle..."
+        "in_vehicle": "You're already in a vehicle...",
+        "spawn_in_progress": "Still waiting for the first vehicle to spawn..."
     },
     "success": {
         "vehicle_parked": "Vehicle Stored"

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,7 +8,7 @@
         "not_enough": "Not enough money",
         "vehicle_occupied": "You can't store this vehicle as it is not empty",
         "in_vehicle": "You're already in a vehicle...",
-        "spawn_in_progress": "Still waiting for the first vehicle to spawn..."
+        "spawn_in_progress": "Please wait for your vehicle to be delivered..."
     },
     "success": {
         "vehicle_parked": "Vehicle Stored"


### PR DESCRIPTION
Slower clients can take several seconds to spawn a vehicle, so adding a lock to prevent players from spawning multiple of them. This prevents duplicated vehicle spawns.