### PR TITLE
feat(server): server event when a vehicle is spawned

### DIFF
--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -44,5 +44,6 @@ lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehic
 
     Entity(veh).state:set('vehicleid', vehicleId, false)
     setVehicleStateToOut(vehicleId, veh, playerVehicle.modelName)
+    TriggerEvent('qbx_garages:server:vehicleSpawned', veh)
     return netId
 end)


### PR DESCRIPTION
Useful for resources that want to apply additional properties on vehicles after they've been spawned in.