### PR TITLE
feat: add option to exclude vehicle categories from locking upon spawn

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -2,6 +2,7 @@ return {
     autoRespawn = false, -- True == auto respawn cars that are outside into your garage on script restart, false == does not put them into your garage and players have to go to the impound
     warpInVehicle = false, -- If false, player will no longer warp into vehicle upon taking the vehicle out.
     doorsLocked = true, -- If true, the doors will be locked upon taking the vehicle out.
+    noLockCategories = { 'motorcycles', 'cycles' }, -- A list of vehicle categories that won't lock upon taking the vehicle out.
     distanceCheck = 5.0, -- The distance that needs to bee clear to let the vehicle spawn, this prevents vehicles stacking on top of each other
     ---calculates the automatic impound fee.
     ---@param vehicleId integer

--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -44,8 +44,9 @@ lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehic
 
     local warpPed = Config.warpInVehicle and GetPlayerPed(source)
     local netId, veh = qbx.spawnVehicle({ spawnSource = spawnCoords, model = playerVehicle.props.model, props = playerVehicle.props, warp = warpPed})
+    local vehicleCategory = exports.qbx_core:GetVehiclesByName()[playerVehicle.modelName].category
 
-    if Config.doorsLocked then
+    if Config.doorsLocked and not lib.table.contains(Config.noLockCategories, vehicleCategory) then
         SetVehicleDoorsLocked(veh, 2)
     end
 


### PR DESCRIPTION
## Description

Currently, if a player decides to take out a motorcycle or a bicycle, it is impossible for them to ride the vehicle, due to the fact that all vehicles are automatically locked by default and qbx_vehiclekeys prevents bikes (motorcycles and bicycles) to be locked/unlocked. This PR aims to fix that by adding a config option for vehicle categories that a developer may want to avoid being locked if `doorsLocked` is true.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
