### PR TITLE
fix: if qbx_vehiclekeys is running, lock using it

### DIFF
--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -46,7 +46,11 @@ lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehic
     local netId, veh = qbx.spawnVehicle({ spawnSource = spawnCoords, model = playerVehicle.props.model, props = playerVehicle.props, warp = warpPed})
 
     if Config.doorsLocked then
-        SetVehicleDoorsLocked(veh, 2)
+        if GetResourceState('qbx_vehiclekeys') == 'started' then
+            TriggerEvent('qb-vehiclekeys:server:setVehLockState', netId, 2)
+        else
+            SetVehicleDoorsLocked(veh, 2)
+        end
     end
 
     TriggerClientEvent('vehiclekeys:client:SetOwner', source, playerVehicle.props.plate)


### PR DESCRIPTION
Solves #132 

If qbx_vehiclekeys is running, rather than set lock status via the native, the vehicle should be locked via qbx_vehiclekeys. While no export exists to control this currently, an internal event in used in the meantime.