### PR TITLE
fix(client): Register blips on client start

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -382,11 +382,6 @@ RegisterNetEvent('qbx_garages:client:garageRegistered', function(name, garage)
     createGarage(name, garage)
 end)
 
-AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
-    createGarages()
-end)
-
-AddEventHandler('onResourceStart', function(resource)
-    if resource ~= cache.resource then return end
+CreateThread(function()
     createGarages()
 end)


### PR DESCRIPTION
## Description
Registers zones and blips on client start instead of resource start / login.
The reason is if a user changes characters garage zones and blips will be duped as they are never removed.
This is better then just removing zones / blips on logout as all the checks are done after entering a zone and pressing `E` or whatever key it is

Closes #136 

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
