### PR TITLE
fix(zones): add extra checks & remove faulty checks

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -288,14 +288,14 @@ local function createZones(garageName, garage, accessPoint, accessPointIndex)
                     coords = accessPoint.coords,
                     radius = 1,
                     onEnter = function()
-                        if accessPoint.dropPoint and cache.vehicle then return end
+                        if not accessPointIndex or not accessPoint.dropPoint or not garage or not garageName then return end
                         lib.showTextUI((garage.type == GarageType.DEPOT and locale('info.impound_e')) or (cache.vehicle and locale('info.park_e')) or locale('info.car_e'))
                     end,
                     onExit = function()
                         lib.hideTextUI()
                     end,
                     inside = function()
-                        if accessPoint.dropPoint and cache.vehicle then return end
+                        if not accessPointIndex or not accessPoint.dropPoint or not garage or not garageName then return end
                         if IsControlJustReleased(0, 38) then
                             if not checkCanAccess(garage) then return end
                             if cache.vehicle and garage.type ~= GarageType.DEPOT then
@@ -320,7 +320,9 @@ local function createZones(garageName, garage, accessPoint, accessPointIndex)
                 if accessPoint.dropPoint then
                     config.drawDropOffMarker(accessPoint.dropPoint)
                 end
-                config.drawGarageMarker(accessPoint.coords.xyz)
+                if accessPoint.coords then
+                    config.drawGarageMarker(accessPoint.coords.xyz)
+                end
             end,
             debug = config.debugPoly,
         })


### PR DESCRIPTION
- onEnter func in createZones lib.zones.sphere was checking if accessPoint.dropPoint or cache.vehicle was valid for returning when it should return when they are not valid. Checks were changed to every parameter needed.

- inside func in createZones lib.zones.sphere was checking if accessPoint.dropPoint or cache.vehicle was valid for returning when it should return when they are not valid. Checks were changed to every parameter needed.

- Made sure to check for the existence of accessPoint.coords before using config.drawGarageMarker to not run into any nil issues.

## Description

I have tested qbx_garages after issue #133 and saw that the disappearing storage points were not the only issue, but some checks were making the functionalities completely obsolete. I have fixed it with the required checks and tested it in-game.

## Checklist
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
