### PR TITLE
fix(server/spawn-vehicle): lock state conflict.

### DIFF
--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -68,6 +68,8 @@ lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehic
         end
     end
 
+    playerVehicle.props.lockState = 1 -- Modify the veh props lock state here to avoid conflicts with the vehicleConfig.noLock system.
+    
     local warpPed = Config.warpInVehicle and GetPlayerPed(source)
     local netId, veh = qbx.spawnVehicle({ spawnSource = spawnCoords, model = playerVehicle.props.model, props = playerVehicle.props, warp = warpPed})
 


### PR DESCRIPTION
As discussed in general-support, with the vehicleConfig.noLock enabled for bikes as an example, no lock statebag is set but lib vehicle properties natively sets them locked because of the parking function here: <https://github.com/Qbox-project/qbx_garages/blob/main/client/main.lua#L231>.

This PR allows us to fully handle lock states with the statebag and simply have the vehicle unlocked by default if noLock applies.

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
