### PR TITLE
feat(mutex): implement mutex for spawn locking in garage system

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -51,16 +51,16 @@ local function kickOutPeds(vehicle)
     end
 end
 
-local spawnLock = false
-
+local mutex = require 'client/mutex' ()
 ---@param vehicleId number
 ---@param garageName string
 ---@param accessPoint integer
 local function takeOutOfGarage(vehicleId, garageName, accessPoint)
-    if spawnLock then
+    if not mutex:acquire() then
         exports.qbx_core:Notify(locale('error.spawn_in_progress'))
+        return
     end
-    spawnLock = true
+
     local success, result = pcall(function()
         if cache.vehicle then
             exports.qbx_core:Notify(locale('error.in_vehicle'))
@@ -85,7 +85,8 @@ local function takeOutOfGarage(vehicleId, garageName, accessPoint)
             SetVehicleEngineOn(veh, true, true, false)
         end
     end)
-    spawnLock = false
+
+    mutex:release()
     assert(success, result)
 end
 

--- a/client/mutex.lua
+++ b/client/mutex.lua
@@ -1,0 +1,25 @@
+local Mutex = {}
+Mutex.__index = Mutex
+
+function Mutex:new()
+    return setmetatable({ locked = false }, self)
+end
+
+-- atomic-style exchange
+function Mutex:acquire()
+    local locked = self.locked
+    if locked then
+        return false
+    end
+
+    self.locked = true
+    return true
+end
+
+function Mutex:release()
+    self.locked = false
+end
+
+return function()
+    return Mutex:new()
+end

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -16,6 +16,7 @@ shared_scripts {
 
 client_scripts {
     '@qbx_core/modules/playerdata.lua',
+    'client/mutex.lua',
     'client/main.lua',
 }
 


### PR DESCRIPTION
## Description

Replaces the previous `spawnLock` flag with a mutex to prevent concurrent vehicle spawn operations.
Adds the mutex module to the client scripts and updates the garage take‑out logic to use `acquire()` and `release()`

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
