### PR TITLE
fix: secure garage vehicle storage and retrieval

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -232,8 +232,10 @@ local function parkVehicle(vehicle, garageName)
         kickOutPeds(vehicle)
         SetVehicleDoorsLocked(vehicle, 2)
         Wait(1500)
-        lib.callback.await('qbx_garages:server:parkVehicle', false, NetworkGetNetworkIdFromEntity(vehicle), lib.getVehicleProperties(vehicle), garageName)
-        exports.qbx_core:Notify(locale('success.vehicle_parked'), 'primary', 4500)
+        local parked = lib.callback.await('qbx_garages:server:parkVehicle', false, NetworkGetNetworkIdFromEntity(vehicle), lib.getVehicleProperties(vehicle), garageName)
+        if parked then
+            exports.qbx_core:Notify(locale('success.vehicle_parked'), 'primary', 4500)
+        end
     else
         exports.qbx_core:Notify(locale('error.vehicle_occupied'), 'error', 3500)
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -112,6 +112,8 @@ end
 function GetPlayerVehicleFilter(source, garageName)
     local player = exports.qbx_core:GetPlayer(source)
     local garage = Garages[garageName]
+    if not player or not garage then return {} end
+
     local filter = {}
     filter.citizenid = not garage.shared and player.PlayerData.citizenid or nil
     filter.states = garage.states or VehicleState.GARAGED
@@ -139,6 +141,8 @@ function TryGetGarage(source, garageName)
 end
 
 local function getCanAccessGarage(player, garage)
+    if not player or not garage then return false end
+
     if garage.groups and not exports.qbx_core:HasPrimaryGroup(player.PlayerData.source, garage.groups) then
         return false
     end
@@ -151,9 +155,12 @@ end
 ---@param playerVehicle PlayerVehicle
 ---@return VehicleType
 local function getVehicleType(playerVehicle)
-    if VEHICLES[playerVehicle.modelName].category == 'helicopters' or VEHICLES[playerVehicle.modelName].category == 'planes' then
+    local vehicle = playerVehicle and VEHICLES[playerVehicle.modelName]
+    if not vehicle then return end
+
+    if vehicle.category == 'helicopters' or vehicle.category == 'planes' then
         return VehicleType.AIR
-    elseif VEHICLES[playerVehicle.modelName].category == 'boats' then
+    elseif vehicle.category == 'boats' then
         return VehicleType.SEA
     else
         return VehicleType.CAR
@@ -190,17 +197,19 @@ end)
 ---@param garageName string
 ---@return boolean
 local function isParkable(source, vehicleId, garageName)
-    local garageType = GetGarageType(garageName)
-    --- DEPOTS are only for retrieving, not storing
-    if garageType == GarageType.DEPOT then return false end
-    if not vehicleId then return false end
-    local player = exports.qbx_core:GetPlayer(source)
     local garage = Garages[garageName]
+    --- DEPOTS are only for retrieving, not storing
+    if not garage or garage.type == GarageType.DEPOT then return false end
+    if not vehicleId then return false end
+
+    local player = exports.qbx_core:GetPlayer(source)
     if not getCanAccessGarage(player, garage) then
         return false
     end
     ---@type PlayerVehicle
     local playerVehicle = exports.qbx_vehicles:GetPlayerVehicle(vehicleId)
+    if not playerVehicle then return false end
+
     if getVehicleType(playerVehicle) ~= garage.vehicleType then
         return false
     end
@@ -212,8 +221,61 @@ local function isParkable(source, vehicleId, garageName)
     return true
 end
 
-lib.callback.register('qbx_garages:server:isParkable', function(source, garage, netId)
+---@param source number
+---@param netId any
+---@return number?
+local function getDrivenVehicle(source, netId)
+    if type(netId) ~= 'number' or netId % 1 ~= 0 then return end
+
     local vehicle = NetworkGetEntityFromNetworkId(netId)
+    local playerPed = GetPlayerPed(source)
+    if vehicle == 0 or playerPed <= 0 or not DoesEntityExist(vehicle) or GetEntityType(vehicle) ~= 2 then return end
+    if GetPedInVehicleSeat(vehicle, -1) ~= playerPed then return end
+    return vehicle
+end
+
+---@param source number
+---@param garage GarageConfig
+---@return boolean
+local function isNearGarageDropPoint(source, garage)
+    local playerPed = GetPlayerPed(source)
+    if playerPed <= 0 then return false end
+
+    local playerCoords = GetEntityCoords(playerPed)
+    for i = 1, #garage.accessPoints do
+        local accessPoint = garage.accessPoints[i]
+        local dropPoint = accessPoint.dropPoint or accessPoint.spawn or accessPoint.coords
+        local hasDropPoint = accessPoint.dropPoint or accessPoint.spawn
+        local radius = hasDropPoint and accessPoint.dropUseRadius or accessPoint.useRadius
+        if #(playerCoords - dropPoint.xyz) <= (radius or 1.5) + 1.0 then
+            return true
+        end
+    end
+    return false
+end
+
+---@param plate string
+---@return string
+local function normalizePlate(plate)
+    return plate:match('^%s*(.-)%s*$'):upper()
+end
+
+---@param props any
+---@param vehicle number
+---@return boolean
+local function areValidProperties(props, vehicle)
+    if type(props) ~= 'table' or type(props.plate) ~= 'string' or type(props.model) ~= 'number' then return false end
+    if normalizePlate(props.plate) ~= normalizePlate(GetVehicleNumberPlateText(vehicle)) then return false end
+    if props.model ~= GetEntityModel(vehicle) then return false end
+
+    local success, encoded = pcall(json.encode, props)
+    return success and type(encoded) == 'string' and #encoded <= 65536
+end
+
+lib.callback.register('qbx_garages:server:isParkable', function(source, garage, netId)
+    local vehicle = getDrivenVehicle(source, netId)
+    if not vehicle then return false end
+
     local vehicleId = Entity(vehicle).state.vehicleid or exports.qbx_vehicles:GetVehicleIdByPlate(GetVehicleNumberPlateText(vehicle))
     return isParkable(source, vehicleId, garage)
 end)
@@ -223,13 +285,17 @@ end)
 ---@param props table ox_lib vehicle props https://github.com/communityox/ox_lib/blob/master/resource/vehicleProperties/client.lua#L3
 ---@param garage string
 lib.callback.register('qbx_garages:server:parkVehicle', function(source, netId, props, garage)
-    assert(Garages[garage] ~= nil, string.format('Garage %s not found. Did you register this garage?', garage))
-    local vehicle = NetworkGetEntityFromNetworkId(netId)
+    local garageConfig = type(garage) == 'string' and Garages[garage]
+    if not garageConfig or not isNearGarageDropPoint(source, garageConfig) then return false end
+
+    local vehicle = getDrivenVehicle(source, netId)
+    if not vehicle or not areValidProperties(props, vehicle) then return false end
+
     local vehicleId = Entity(vehicle).state.vehicleid or exports.qbx_vehicles:GetVehicleIdByPlate(GetVehicleNumberPlateText(vehicle))
     local owned = isParkable(source, vehicleId, garage) --Check ownership
     if not owned then
         exports.qbx_core:Notify(source, locale('error.not_owned'), 'error')
-        return
+        return false
     end
 
     exports.qbx_vehicles:SaveVehicle(vehicle, {
@@ -239,6 +305,7 @@ lib.callback.register('qbx_garages:server:parkVehicle', function(source, netId, 
     })
 
     exports.qbx_core:DeleteVehicle(vehicle)
+    return true
 end)
 
 AddEventHandler('onResourceStart', function(resource)

--- a/server/spawn-vehicle.lua
+++ b/server/spawn-vehicle.lua
@@ -1,4 +1,18 @@
 local logger = require '@qbx_core.modules.logger'
+local spawningVehicles = {}
+
+---@param player table
+---@param garage GarageConfig
+---@return boolean
+local function canAccessGarage(player, garage)
+    if garage.groups and not exports.qbx_core:HasPrimaryGroup(player.PlayerData.source, garage.groups) then
+        return false
+    end
+    if garage.canAccess ~= nil and not garage.canAccess(player.PlayerData.source) then
+        return false
+    end
+    return true
+end
 
 ---@param vehicleId integer
 ---@param modelName string
@@ -12,18 +26,16 @@ end
 
 ---@param player table
 ---@param depotPrice integer
+---@return string?
 local function payDepotPrice(player, depotPrice)
     local cashBalance = player.PlayerData.money.cash
     local bankBalance = player.PlayerData.money.bank
 
     if cashBalance >= depotPrice then
-        player.Functions.RemoveMoney('cash', depotPrice, 'paid-depot')
-        return true
+        return player.Functions.RemoveMoney('cash', depotPrice, 'paid-depot') and 'cash'
     elseif bankBalance >= depotPrice then
-        player.Functions.RemoveMoney('bank', depotPrice, 'paid-depot')
-        return true
+        return player.Functions.RemoveMoney('bank', depotPrice, 'paid-depot') and 'bank'
     end
-    return false
 end
 
 ---@param source number
@@ -32,8 +44,13 @@ end
 ---@param accessPointIndex integer
 ---@return number? netId
 lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehicleId, garageName, accessPointIndex)
+    if type(vehicleId) ~= 'number' or vehicleId % 1 ~= 0 then return end
+    if type(garageName) ~= 'string' then return end
+    if type(accessPointIndex) ~= 'number' or accessPointIndex % 1 ~= 0 then return end
+
+    local player = exports.qbx_core:GetPlayer(source)
     local garage = TryGetGarage(source, garageName)
-    if not garage then return end
+    if not player or not garage or not canAccessGarage(player, garage) then return end
 
     local accessPoint = garage.accessPoints[accessPointIndex]
     if not accessPoint then
@@ -86,25 +103,53 @@ lib.callback.register('qbx_garages:server:spawnVehicle', function (source, vehic
         exports.qbx_core:Notify(source, locale('error.not_owned'), 'error')
         return
     end
+    if type(playerVehicle.props) ~= 'table' or type(playerVehicle.props.plate) ~= 'string'
+        or type(playerVehicle.props.model) ~= 'number' then return end
+
     if garageType == GarageType.DEPOT and FindPlateOnServer(playerVehicle.props.plate) then -- If depot, check if vehicle is not already spawned on the map
         return exports.qbx_core:Notify(source, locale('error.not_impound'), 'error')
     end
 
-    if garageType == GarageType.DEPOT and playerVehicle.depotPrice then
-        local player = exports.qbx_core:GetPlayer(source)
-        OverrideFreeDepotPriceForOutVehicle(playerVehicle)
-        local canPay = payDepotPrice(player, playerVehicle.depotPrice)
+    if spawningVehicles[vehicleId] then return end
+    spawningVehicles[vehicleId] = true
 
-        if not canPay then
-            exports.qbx_core:Notify(source, locale('error.not_enough'), 'error')
+    local paidFrom
+    local depotPrice
+    if garageType == GarageType.DEPOT then
+        OverrideFreeDepotPriceForOutVehicle(playerVehicle)
+        depotPrice = tonumber(playerVehicle.depotPrice) or 0
+        if depotPrice ~= depotPrice or depotPrice < 0 or depotPrice > 100000000 then
+            spawningVehicles[vehicleId] = nil
             return
+        end
+
+        if depotPrice > 0 then
+            paidFrom = payDepotPrice(player, depotPrice)
+            if not paidFrom then
+                spawningVehicles[vehicleId] = nil
+                exports.qbx_core:Notify(source, locale('error.not_enough'), 'error')
+                return
+            end
         end
     end
 
     playerVehicle.props.lockState = 1 -- Modify the veh props lock state here to avoid conflicts with the vehicleConfig.noLock system.
 
     local warpPed = Config.warpInVehicle and GetPlayerPed(source)
-    local netId, veh = qbx.spawnVehicle({ spawnSource = spawnCoords, model = playerVehicle.props.model, props = playerVehicle.props, warp = warpPed})
+    local success, netId, veh = pcall(qbx.spawnVehicle, {
+        spawnSource = spawnCoords,
+        model = playerVehicle.props.model,
+        props = playerVehicle.props,
+        warp = warpPed,
+    })
+    spawningVehicles[vehicleId] = nil
+
+    if not success or not netId or not veh or veh == 0 or not DoesEntityExist(veh) then
+        if paidFrom then
+            player.Functions.AddMoney(paidFrom, depotPrice, 'depot-spawn-refund')
+        end
+        return
+    end
 
     if Config.doorsLocked then
         if GetResourceState('qbx_vehiclekeys') == 'started' then


### PR DESCRIPTION
## What changed
- require the requester to be driving the exact network vehicle being parked
- require parking at a configured drop point and validate the garage before indexing it
- validate saved property plate/model identity and cap serialized property size
- safely handle missing players, vehicles, garages, and model definitions
- enforce garage access again during server-side spawning
- validate callback argument types and vehicle property shape
- add a per-vehicle server spawn lock to prevent concurrent duplicate retrieval
- honor money-removal failures and refund depot fees when spawning fails
- only show the client success notification after the server confirms parking

## Why
Parking callbacks accepted arbitrary network IDs and properties without proving the caller controlled the vehicle or was at the garage. Shared vehicles could be remotely stored/deleted, invalid garage input raised an assertion, and concurrent retrieval requests could duplicate a vehicle or charge a fee without a successful spawn.

This server-side lock complements the open client mutex PR; it protects against concurrent or modified-client requests.

## Validation
- git diff --check
- direct Lua review of owned/shared garage, depot, failed-payment, failed-spawn, and parking flows
- checked against open PR #150 to avoid duplicating its client-only mutex